### PR TITLE
Support matching on request body for non-GET/HEAD requests

### DIFF
--- a/fakehr.js
+++ b/fakehr.js
@@ -35,13 +35,19 @@
       this.stop();
       this.clear();
     },
-    match: function(method, url, readyState){
+    match: function(method, url, data, readyState){
+      if (data === undefined) {
+        data = null;
+      } else if (typeof data === "number") {
+        readyState = data;
+        data = null;
+      }
       if (readyState === undefined) { readyState = 1;}
 
       var requests = this.requests;
       for (var i = requests.length - 1; i >= 0; i--) {
         var request = requests[i];
-        if(request.method.toLowerCase() === method.toLowerCase() && request.url === url && request.readyState === readyState) {
+        if(request.method.toLowerCase() === method.toLowerCase() && request.url === url && request.readyState === readyState && JSON.stringify(data) === JSON.stringify(request.requestBody)) {
           return request;
         }
       };

--- a/test/match_test.js
+++ b/test/match_test.js
@@ -31,3 +31,22 @@ test("only returns first object found", function(){
 
   equal(fakehr.match('get', '/a/path'), xhr);
 });
+
+test("matches any request by HTTP method, url, and data", function(){
+  var xhr = new XMLHttpRequest();
+  xhr.open('post', '/a/path');
+  xhr.send({ foo: 'bar' });
+  equal(fakehr.match('post', '/a/path', { foo: 'bar' }, 1), xhr);
+});
+
+test("differentiates a request for the same path by data", function(){
+  var xhr = new XMLHttpRequest();
+  var xhr2 = new XMLHttpRequest();
+  xhr.open('post', '/a/path', { foo: 'bar' });
+  xhr.send({ foo: 'bar' });
+  xhr2.open('post', '/a/path', { bar: 'baz' });
+  xhr2.send({ bar: 'baz' });
+
+  equal(fakehr.match('post', '/a/path', { foo: 'bar' }), xhr);
+  equal(fakehr.match('post', '/a/path', { bar: 'baz' }), xhr2);
+});


### PR DESCRIPTION
This is a very simplistic implementation that doesn't check object equality beyond JSON.stringify. The real use case for me is to assert that requests are resulting in specific data being posted.
