### PR TITLE
Add ability to distinguish POST requests by body.

### DIFF
--- a/fakehr.js
+++ b/fakehr.js
@@ -35,13 +35,23 @@
       this.stop();
       this.clear();
     },
-    match: function(method, url, readyState){
+
+    /**
+     * Matches the given request with mocked.
+     * @param method
+     * @param url
+     * @param readyState
+     * @param requestBody The request body for advanced comparison (useful for POST requests with the same url).
+     * @returns {Object} the matched request if found or undefined.
+     */
+    match: function(method, url, readyState, requestBody){
       if (readyState === undefined) { readyState = 1;}
 
       var requests = this.requests;
       for (var i = requests.length - 1; i >= 0; i--) {
         var request = requests[i];
-        if(request.method.toLowerCase() === method.toLowerCase() && request.url === url && request.readyState === readyState) {
+        if(request.method.toLowerCase() === method.toLowerCase() && request.url === url && request.readyState === readyState &&
+          (!requestBody || request.requestBody === requestBody)) {
           return request;
         }
       };

--- a/test/match_test.js
+++ b/test/match_test.js
@@ -31,3 +31,15 @@ test("only returns first object found", function(){
 
   equal(fakehr.match('get', '/a/path'), xhr);
 });
+
+test("2 post requests with the same url, yet different body", function() {
+  var xhr = new XMLHttpRequest();
+  xhr.open('post', '/a/path', true);
+  xhr.send('First POST');
+
+  var xhr2 = new XMLHttpRequest();
+  xhr2.open('post', '/a/path', true);
+  xhr2.send('Second POST');
+  equal(fakehr.match('post', '/a/path', 1, 'First POST'), xhr);
+  equal(fakehr.match('post', '/a/path', 1, 'Second POST'), xhr2);
+});


### PR DESCRIPTION
We use one endpoint for all requests and distinguish them by a post parameter.
