### PR TITLE
Support extended matching with regular expressions and callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ Clears the array of intercepted requests. If `response` wasn't triggered on thes
 ###`fakehr.reset()`
 Clears the intercepted requests and restores the native `XMLHttpRequest` object.
 
-###`fakehr.match(httpMethod, url, [readyState])`
+###`fakehr.match(httpMethod, url, [readyState], [requestBody])`
 Searches the intercepted requests for the first open (`readyState` of `1`) request whose
 HTTP method and url match the passed arguments. Optionally you can provide a
 numeric [`readyState` code value](http://www.w3.org/TR/XMLHttpRequest/#states) to search for
-requests in that state.
+requests in that state, and a request body to match different requests to the same URL. Both
+the `url` and `requestBody` parameters can be specified as regular expressions or callbacks.
+Callbacks are invoked the expected value as their only argument and are expected to return a
+boolean indicating whether the value matched or not.
 
 ## Why not Sinon.JS or something else?
 Sinon.JS includes much more than just request mocking. I wanted a single purpose library. Most other

--- a/fakehr.js
+++ b/fakehr.js
@@ -11,6 +11,16 @@
   // it can be restored later
   var nativeRequest = window.XMLHttpRequest;
 
+  function extendedMatch(value, expected) {
+    if (value instanceof RegExp) {
+      return value.test(expected);
+    } else if (typeof value === 'function') {
+      return value(expected);
+    } else {
+      return value === expected;
+    }
+  }
+
   var fakehr = {
     addRequest: function(r){
       this.requests.push(r);
@@ -55,9 +65,9 @@
 
         if (request.method.toLowerCase() !== method.toLowerCase()) continue;
 
-        if (request.url !== url) continue;
+        if (!extendedMatch(url, request.url)) continue;
 
-        if (requestBody && request.requestBody !== requestBody) continue;
+        if (requestBody && !extendedMatch(requestBody, request.requestBody)) continue;
 
         return request;
       }

--- a/fakehr.js
+++ b/fakehr.js
@@ -50,13 +50,19 @@
       var requests = this.requests;
       for (var i = requests.length - 1; i >= 0; i--) {
         var request = requests[i];
-        if(request.method.toLowerCase() === method.toLowerCase() && request.url === url && request.readyState === readyState &&
-          (!requestBody || request.requestBody === requestBody)) {
-          return request;
-        }
-      };
+
+        if (request.readyState !== readyState) continue;
+
+        if (request.method.toLowerCase() !== method.toLowerCase()) continue;
+
+        if (request.url !== url) continue;
+
+        if (requestBody && request.requestBody !== requestBody) continue;
+
+        return request;
+      }
     }
-  }
+  };
 
   window.fakehr = fakehr;
 })();

--- a/test/match_test.js
+++ b/test/match_test.js
@@ -43,3 +43,38 @@ test("2 post requests with the same url, yet different body", function() {
   equal(fakehr.match('post', '/a/path', 1, 'First POST'), xhr);
   equal(fakehr.match('post', '/a/path', 1, 'Second POST'), xhr2);
 });
+
+test("matches URL and request body using a regular expression", function(){
+  var xhr1 = new XMLHttpRequest();
+  xhr1.open('get', '/a/path?param=value');
+
+  equal(fakehr.match('get', /\/a\/path\?.*/), xhr1);
+  ok(!fakehr.match('get', /bad\/path/));
+
+  var xhr2 = new XMLHttpRequest();
+  xhr2.open('post', '/a/path');
+  xhr2.send('body');
+
+  equal(fakehr.match('post', '/a/path', 1, /body/), xhr2);
+  ok(!fakehr.match('get', '/a/path', 1, /bad body/));
+});
+
+test("matches URL and request body using a callback", function(){
+  var url = '/a/path';
+  var body = 'body';
+  var xhr = new XMLHttpRequest();
+  xhr.open('post', url);
+  xhr.send(body);
+
+  var makeCallback = function(matches, value) {
+    return function(arg) {
+      equal(value, arg);
+      return matches;
+    };
+  };
+
+  equal(fakehr.match('post', makeCallback(true, url), 1), xhr);
+  equal(fakehr.match('post', url, 1, makeCallback(true, body)), xhr);
+  ok(!fakehr.match('post', makeCallback(false, url)));
+  ok(!fakehr.match('post', url, 1, makeCallback(false, body)));
+});


### PR DESCRIPTION
I've found it very useful to be able to match URLs using a regex (to ignore long query params), and to match the complex request bodies using a callback (using JSONPath or the like).
